### PR TITLE
19951 Update devcontainer requirements to match engine recipes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Get latest howso-engine-py version
+        if: inputs.build-type != 'release'
+        id: get-hse-py-version
+        run: |
+          latest=$(pip index versions howso-engine | grep -oP '(\d+\.)?(\d+\.)?(\*|\d+)' | sort -V | tail -n1)
+          echo "latest_version=$latest" >> $GITHUB_OUTPUT
+
+      - name: Build Docker Image (no push)
+        if: inputs.build-type != 'release'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: |
+            PY_VERSION=${{ matrix.python-ver }}
+            HOWSO_ENGINE_VERSION=${{ steps.get-hse-py-version.outputs.latest_version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
       - name: Build & Push Docker image
         if: inputs.build-type == 'release'
         uses: docker/build-push-action@v5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,16 @@
-ipykernel>=6.0.0,<7
-matplotlib>=3.4.0,<4
+babel~=2.0
+geopandas>=0.11.0
+howso-visuals~=1.0
+ipykernel~=6.0
+jupyter-core~=4.0
+kaleido==0.1.0.post1; sys_platform == "win32"
+kaleido; sys_platform != "win32"
+matplotlib~=3.4
+notebook~=6.0
 numpy
-pandas
+pandas[parquet]~=2.0
 plotly>=5.7.0
 pmlb>=1.0
-seaborn
-howso-visuals
+scikit-learn
 # This can be dropped when we stop supporting Python 3.8
-ipython<8.13; python_version=='3.8'
+ipython<8.13; python_version<'3.9'


### PR DESCRIPTION
The `howso` devcontainer requirements had fallen out of date with what's currently used by the engine recipes. This gets it back in alignment.