### PR TITLE
23786: Fixes dependency conflict that prevents newer versions of howso-engine-py from being installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# OS Stuff
+.DS_Store
+
+# Misc
+.direnv
+.envrc
+**/*.dump*
+**/*.trace
+dumps
+traces
+howso/docs/build
+howso/docs/source/_build
+howso/docs/source/auto_examples
+howso/howso-engine
+howso/resources
+local/
+
+# Do not ignore the thumbnails used by sphinx-gallery
+!howso/docs/source/auto_examples/images/thumb/*.png
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+.Python
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# UV installer
+uv.lock
+
+# Unit test / coverage reports
+**/junit/**
+htmlcov/
+.tox/
+test
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Idea
+.idea
+*.iml
+
+# Self Created
+target/
+v/
+local/
+
+# Example output files
+report.html
+howso/examples/output.csv
+
+# VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Cache files
+.howso_recent_cache*
+
+# Verification script
+howso_stacktrace.txt
+howso_stacktrace.txt
+setup.cfg
+
+# Local requirements file
+/requirements-dev.txt
+/requirements.txt
+/dev-requirements.txt

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-devcontainers-3.12

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+devcontainers-3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 babel~=2.0
 geopandas>=0.11.0
-howso-visuals~=1.0
+howso-visuals
 ipykernel>=6.0.0
 jupyter-core>=4.7.0
 kaleido==0.1.0.post1; sys_platform == "win32"
 kaleido; sys_platform != "win32"
-matplotlib~=3.4
+matplotlib
 notebook>6.0.0
 numpy
 pandas[parquet]~=2.0


### PR DESCRIPTION
Resolves #23 